### PR TITLE
feat(deal-screen): public Deal Screen landing page + order form (SAL-22)

### DIFF
--- a/src/app/deal-screen/page.tsx
+++ b/src/app/deal-screen/page.tsx
@@ -1,0 +1,253 @@
+import type { Metadata } from "next";
+import {
+  CheckCircle2,
+  Gauge,
+  ScrollText,
+  ShieldAlert,
+  Sparkles,
+  Target,
+} from "lucide-react";
+
+import FAQSection from "@/components/shared/FAQSection";
+import type { FAQItem } from "@/data/faqs";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import DealScreenOrderForm from "@/components/deal-screen/DealScreenOrderForm";
+
+export const metadata: Metadata = {
+  title: "Deal Screen — Will It Appraise? Know Before You Buy",
+  description:
+    "The $49 Deal Screen is an appraiser-grade, decision-support read on your next purchase: a go / renegotiate / pass verdict, after-repair value range, MLS-verified comps, margin-killing risk flags, and a pro-forma with break-evens. Not an appraisal.",
+  alternates: {
+    canonical: "https://www.roihomesvc.com/deal-screen",
+  },
+  openGraph: {
+    title: "Deal Screen — Will It Appraise? Know Before You Buy",
+    description:
+      "An appraiser-grade, $49 decision-support read on your next deal: verdict, ARV range, MLS-verified comps, risk flags, and a pro-forma with break-evens. Decision-support only — not an appraisal.",
+    url: "https://www.roihomesvc.com/deal-screen",
+  },
+};
+
+const whatYouGet: { icon: typeof CheckCircle2; title: string; body: string }[] =
+  [
+    {
+      icon: Gauge,
+      title: "A clear verdict: go / renegotiate / pass",
+      body: "A straight call on the deal in front of you — not a wall of numbers to interpret yourself.",
+    },
+    {
+      icon: Target,
+      title: "After-repair value (ARV) range",
+      body: "A defensible value range for the finished property, grounded in real market evidence.",
+    },
+    {
+      icon: ScrollText,
+      title: "MLS-verified comparable sales",
+      body: "The actual sold comps behind the number, hand-checked against MLS data — not an automated guess.",
+    },
+    {
+      icon: ShieldAlert,
+      title: "The risk flags that kill margin",
+      body: "Functional obsolescence, location drags, condition issues, and over-improvement called out before they cost you.",
+    },
+    {
+      icon: Sparkles,
+      title: "A pro-forma with break-evens",
+      body: "Your numbers run forward to the break-even price and the cushion you have to work with.",
+    },
+  ];
+
+const dealScreenFAQs: FAQItem[] = [
+  {
+    question: "Is this an appraisal?",
+    answer:
+      "No. The Deal Screen is decision-support — a fast, appraiser-grade read to help you decide whether to move on a property. It is not a USPAP appraisal and is not intended for lending, loan underwriting, or any legal or tax use. When you need a certified value for a lender, court, or the IRS, order a full appraisal.",
+  },
+  {
+    question: "How fast will I get it?",
+    answer:
+      "Most Deal Screens are turned around quickly so you can act before a deal moves. You'll receive your verdict, ARV range, comps, risk flags, and pro-forma in a single, easy-to-read report.",
+  },
+  {
+    question: "What do I need to provide?",
+    answer:
+      "Just the property address to start. If you have a contract price and a target after-repair value, add them — it sharpens the read and lets us frame your break-evens against your actual numbers.",
+  },
+  {
+    question: "Who is the Deal Screen for?",
+    answer:
+      "Investors, flippers, and buyers who want an experienced, appraiser-grade gut-check before they commit. It's built to catch the margin-killers early and tell you whether the price makes sense.",
+  },
+  {
+    question: "Why $49?",
+    answer:
+      "It's an introductory price (normally $149) to make a fast, professional read accessible on every deal you're weighing. The goal is to save you from the bad ones and give you conviction on the good ones.",
+  },
+  {
+    question: "Does a verdict guarantee the property's value?",
+    answer:
+      "No. The Deal Screen is a professional opinion to support your decision — it does not guarantee a value, a sale price, or a lender's appraised value. You remain responsible for your own purchase decision.",
+  },
+];
+
+export default function DealScreenPage() {
+  return (
+    <div>
+      {/* HERO */}
+      <section className="relative overflow-hidden bg-gradient-to-br from-deep-charcoal to-accent text-white">
+        <div className="container mx-auto grid items-center gap-12 px-4 py-16 sm:px-6 md:py-24 lg:grid-cols-2 lg:px-8">
+          <div>
+            <span className="inline-flex items-center gap-2 rounded-full bg-highlight px-4 py-1.5 text-sm font-semibold text-highlight-foreground">
+              <Sparkles className="h-4 w-4" />
+              Intro price &mdash; $49 (normally $149)
+            </span>
+            <h1 className="mt-6 text-balance text-4xl font-bold leading-tight md:text-5xl lg:text-6xl">
+              Will It Appraise? Know Before You Buy.
+            </h1>
+            <p className="mt-6 max-w-xl text-balance text-lg leading-relaxed text-slate-200">
+              The Deal Screen is an appraiser-grade, decision-support read on
+              your next purchase &mdash; a fast, clear answer on whether the
+              price makes sense, so you can move with conviction or walk away
+              before it costs you.
+            </p>
+            <div className="mt-8 flex flex-col gap-4 sm:flex-row">
+              <Button
+                asChild
+                size="lg"
+                variant="highlight"
+                className="text-base"
+              >
+                <a href="#order-form">Screen My Deal &mdash; $49</a>
+              </Button>
+              <Button
+                asChild
+                size="lg"
+                variant="outline"
+                className="border-white/40 bg-transparent text-base text-white hover:bg-white/10 hover:text-white"
+              >
+                <a href="#what-you-get">See What You Get</a>
+              </Button>
+            </div>
+            <p className="mt-6 text-sm text-slate-300">
+              Decision-support only &mdash; not an appraisal, not for lending.
+            </p>
+          </div>
+
+          {/* Inline order form as the primary conversion point */}
+          <div className="scroll-mt-24 lg:justify-self-end" id="order-form">
+            <DealScreenOrderForm
+              id="hero-order-form"
+              className="w-full max-w-md bg-background text-foreground shadow-2xl"
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* WHAT YOU GET FOR $49 */}
+      <section
+        id="what-you-get"
+        className="container mx-auto scroll-mt-24 px-4 py-16 sm:px-6 md:py-24 lg:px-8"
+      >
+        <div className="mx-auto mb-12 max-w-2xl text-center">
+          <h2 className="text-3xl font-bold md:text-4xl">
+            What you get for $49
+          </h2>
+          <p className="mt-4 text-lg text-muted-foreground">
+            A complete, appraiser-grade read on the deal &mdash; everything you
+            need to decide, in one report.
+          </p>
+        </div>
+
+        <div className="mx-auto grid max-w-5xl gap-6 sm:grid-cols-2">
+          {whatYouGet.map(({ icon: Icon, title, body }) => (
+            <Card key={title} className="h-full">
+              <CardContent className="flex gap-4 p-6">
+                <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg bg-accent/10 text-accent">
+                  <Icon className="h-6 w-6" />
+                </div>
+                <div>
+                  <h3 className="text-lg font-semibold">{title}</h3>
+                  <p className="mt-1 text-muted-foreground">{body}</p>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <p className="mx-auto mt-8 flex max-w-3xl items-center justify-center gap-2 text-center text-sm text-muted-foreground">
+          <CheckCircle2 className="h-4 w-4 shrink-0 text-highlight" />
+          Built and reviewed by a Florida appraisal professional with 30+ years
+          in the market.
+        </p>
+      </section>
+
+      {/* PRICE FRAMING */}
+      <section className="bg-light-gray py-16 md:py-24">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <Card className="mx-auto max-w-3xl border-accent/20 shadow-md">
+            <CardContent className="flex flex-col items-center gap-6 p-8 text-center md:p-12">
+              <h2 className="text-3xl font-bold md:text-4xl">
+                One smart deal pays for a thousand screens
+              </h2>
+              <div className="flex items-end justify-center gap-3">
+                <span className="text-2xl font-medium text-muted-foreground line-through">
+                  $149
+                </span>
+                <span className="text-5xl font-bold text-accent md:text-6xl">
+                  $49
+                </span>
+              </div>
+              <p className="max-w-xl text-balance text-muted-foreground">
+                Introductory pricing for a fast, professional read on every deal
+                you&rsquo;re weighing. Catch the margin-killers before you sign,
+                and walk into the good ones with conviction.
+              </p>
+              <Button asChild size="lg" className="text-base">
+                <a href="#order-form">Screen My Deal &mdash; $49</a>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <FAQSection
+        title="Deal Screen FAQs"
+        subtitle="The short answers — including the one everyone asks first."
+        items={dealScreenFAQs}
+        className="bg-background"
+      />
+
+      {/* FINAL ORDER FORM — primary conversion point */}
+      <section className="bg-light-gray py-16 md:py-24">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto mb-10 max-w-2xl text-center">
+            <h2 className="text-3xl font-bold md:text-4xl">
+              Screen your deal in minutes
+            </h2>
+            <p className="mt-4 text-lg text-muted-foreground">
+              Enter the address to get your verdict, ARV range, comps, risk
+              flags, and pro-forma.
+            </p>
+          </div>
+          <div className="mx-auto max-w-2xl">
+            <DealScreenOrderForm id="bottom-order-form" />
+          </div>
+        </div>
+      </section>
+
+      {/* Compliance line */}
+      <section className="bg-background py-8">
+        <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+          <p className="mx-auto max-w-3xl text-center text-sm text-muted-foreground">
+            Decision-support only &mdash; not an appraisal, not for lending. The
+            Deal Screen is a professional opinion to support your purchase
+            decision and does not guarantee any value, sale price, or appraised
+            value.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/deal-screen/start/page.tsx
+++ b/src/app/deal-screen/start/page.tsx
@@ -1,0 +1,118 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Lock, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export const metadata: Metadata = {
+  title: "Complete Your Deal Screen — $49",
+  description:
+    "Complete your $49 Deal Screen order. Secure checkout for an appraiser-grade, decision-support read on your deal.",
+  alternates: {
+    canonical: "https://www.roihomesvc.com/deal-screen/start",
+  },
+  // Checkout/intermediate funnel page — keep it out of the index.
+  robots: { index: false, follow: false },
+};
+
+interface StartPageProps {
+  // Next.js 15 App Router delivers searchParams as a Promise.
+  searchParams: Promise<{
+    address?: string;
+    contract?: string;
+    arv?: string;
+  }>;
+}
+
+/** Format a raw digit string as USD, falling back to the raw value. */
+function formatCurrency(raw?: string): string | null {
+  if (!raw) return null;
+  const num = Number(raw);
+  if (isNaN(num)) return raw;
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  }).format(num);
+}
+
+export default async function DealScreenStartPage({
+  searchParams,
+}: StartPageProps) {
+  const { address, contract, arv } = await searchParams;
+
+  const propertyLabel = address?.trim() || "your property";
+  const contractDisplay = formatCurrency(contract);
+  const arvDisplay = formatCurrency(arv);
+
+  return (
+    <div className="container mx-auto px-4 py-16 sm:px-6 md:py-24 lg:px-8">
+      <Card className="mx-auto max-w-xl shadow-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-accent/10 text-accent">
+            <Lock className="h-6 w-6" />
+          </div>
+          <CardTitle className="text-2xl text-primary">
+            Complete your $49 Deal Screen for {propertyLabel}
+          </CardTitle>
+          <CardDescription>
+            You&rsquo;re one step from your verdict, ARV range, MLS-verified
+            comps, risk flags, and pro-forma.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <dl className="divide-y rounded-lg border bg-secondary/40 text-sm">
+            <div className="flex items-center justify-between gap-4 p-4">
+              <dt className="font-medium text-muted-foreground">Property</dt>
+              <dd className="text-right font-semibold">{propertyLabel}</dd>
+            </div>
+            {contractDisplay && (
+              <div className="flex items-center justify-between gap-4 p-4">
+                <dt className="font-medium text-muted-foreground">
+                  Contract price
+                </dt>
+                <dd className="text-right font-semibold">{contractDisplay}</dd>
+              </div>
+            )}
+            {arvDisplay && (
+              <div className="flex items-center justify-between gap-4 p-4">
+                <dt className="font-medium text-muted-foreground">
+                  Target ARV
+                </dt>
+                <dd className="text-right font-semibold">{arvDisplay}</dd>
+              </div>
+            )}
+            <div className="flex items-center justify-between gap-4 p-4">
+              <dt className="font-medium text-muted-foreground">Deal Screen</dt>
+              <dd className="text-right font-semibold text-accent">$49</dd>
+            </div>
+          </dl>
+
+          <div className="flex items-start gap-3 rounded-lg border border-accent/20 bg-accent/5 p-4 text-sm text-muted-foreground">
+            <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-accent" />
+            <p>
+              Secure $49 checkout is being wired up. Your details have been
+              captured &mdash; payment will be enabled here shortly so you can
+              complete your order.
+            </p>
+          </div>
+
+          <Button asChild variant="outline" className="w-full">
+            <Link href="/deal-screen">Back to Deal Screen</Link>
+          </Button>
+
+          <p className="text-center text-xs text-muted-foreground">
+            Decision-support only &mdash; not an appraisal, not for lending.
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/deal-screen/DealScreenOrderForm.tsx
+++ b/src/components/deal-screen/DealScreenOrderForm.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { ArrowRight, MapPin } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// Contract price / target ARV come in as free-text so users can paste
+// "$450,000" or "450000"; we normalize to digits before validating range.
+const numericOptional = z
+  .string()
+  .optional()
+  .refine(
+    (val) => {
+      if (!val) return true;
+      const digitsOnly = val.replace(/[^0-9.]/g, "");
+      const num = parseFloat(digitsOnly);
+      return !isNaN(num) && num > 0 && num <= 100_000_000;
+    },
+    { message: "Enter a valid dollar amount" }
+  );
+
+const orderFormSchema = z.object({
+  address: z
+    .string()
+    .min(8, "Please enter a complete property address")
+    .max(200, "Address is too long"),
+  contract: numericOptional,
+  arv: numericOptional,
+});
+
+type OrderFormValues = z.infer<typeof orderFormSchema>;
+
+/** Strip formatting characters so query params carry clean numeric values. */
+function normalizeAmount(value?: string): string {
+  if (!value) return "";
+  const digitsOnly = value.replace(/[^0-9.]/g, "");
+  return digitsOnly;
+}
+
+interface DealScreenOrderFormProps {
+  /** Optional id so the hero CTA can scroll/focus the form. */
+  id?: string;
+  className?: string;
+}
+
+export default function DealScreenOrderForm({
+  id = "order-form",
+  className,
+}: DealScreenOrderFormProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const form = useForm<OrderFormValues>({
+    resolver: zodResolver(orderFormSchema),
+    defaultValues: {
+      address: "",
+      contract: "",
+      arv: "",
+    },
+  });
+
+  const onSubmit = (values: OrderFormValues) => {
+    setIsSubmitting(true);
+
+    const params = new URLSearchParams();
+    params.set("address", values.address.trim());
+
+    const contract = normalizeAmount(values.contract);
+    if (contract) params.set("contract", contract);
+
+    const arv = normalizeAmount(values.arv);
+    if (arv) params.set("arv", arv);
+
+    router.push(`/deal-screen/start?${params.toString()}`);
+  };
+
+  return (
+    <Card id={id} className={className}>
+      <CardHeader>
+        <CardTitle className="text-2xl text-primary">
+          Start Your $49 Deal Screen
+        </CardTitle>
+        <CardDescription>
+          Enter the property address. Add the contract price and your target
+          after-repair value if you have them &mdash; it sharpens the read.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Property Address
+                    <span className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <div className="relative">
+                      <MapPin className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                      <Input
+                        className="pl-9"
+                        placeholder="123 Main St, Orlando, FL 32801"
+                        autoComplete="street-address"
+                        {...field}
+                      />
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2">
+              <FormField
+                control={form.control}
+                name="contract"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Contract Price</FormLabel>
+                    <FormControl>
+                      <Input
+                        inputMode="decimal"
+                        placeholder="$300,000"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>Optional</FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="arv"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Target ARV</FormLabel>
+                    <FormControl>
+                      <Input
+                        inputMode="decimal"
+                        placeholder="$425,000"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormDescription>
+                      After-repair value, optional
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <Button
+              type="submit"
+              size="lg"
+              disabled={isSubmitting}
+              className="group w-full"
+            >
+              {isSubmitting ? "Starting…" : "Continue to Checkout — $49"}
+              <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
+            </Button>
+
+            <p className="text-center text-xs text-muted-foreground">
+              Decision-support only &mdash; not an appraisal, not for lending.
+            </p>
+          </form>
+        </Form>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
Implements the public **/deal-screen** landing page, the address-entry order form, and a `/deal-screen/start` checkout placeholder.

Fixes SAL-22

- Hero with the address-entry order form as the primary CTA
- "What you get for $49" value section + $49-vs-$149 framing
- FAQ (incl. "Is this an appraisal?" → decision-support, not an appraisal)
- Compliance line; SEO metadata (canonical + OpenGraph)
- Reuses the existing component library; Navbar/Footer come from the layout

Production `next build` passes. Stripe checkout and the full legal disclaimer are follow-up tickets (SAL-29 / Stripe checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)