### PR TITLE
feat(deal-screen): disclaimer + AI-vs-appraiser FAQ/moat + funnel analytics (SAL-29/38/39/48/55)

### DIFF
--- a/src/app/deal-screen/page.tsx
+++ b/src/app/deal-screen/page.tsx
@@ -13,6 +13,9 @@ import type { FAQItem } from "@/data/faqs";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import DealScreenOrderForm from "@/components/deal-screen/DealScreenOrderForm";
+import DealScreenDisclaimer from "@/components/deal-screen/DealScreenDisclaimer";
+import DealScreenMoatSection from "@/components/deal-screen/DealScreenMoatSection";
+import DealScreenPageAnalytics from "@/components/deal-screen/DealScreenPageAnalytics";
 
 export const metadata: Metadata = {
   title: "Deal Screen — Will It Appraise? Know Before You Buy",
@@ -89,11 +92,24 @@ const dealScreenFAQs: FAQItem[] = [
     answer:
       "No. The Deal Screen is a professional opinion to support your decision — it does not guarantee a value, a sale price, or a lender's appraised value. You remain responsible for your own purchase decision.",
   },
+  {
+    question: "Why can't I just ask a regular AI chatbot what it's worth?",
+    answer:
+      "Generic AI hallucinates valuation theory, invents comp adjustments with no market support, and shortcuts straight to a number to be helpful — skipping the comp selection, condition reads, and risk checks that decide whether a price makes sense. It lacks real appraiser domain knowledge and only has public data to draw on, so the result is a public-grade guess, not an appraiser-grade read. The Deal Screen is built on a proprietary, appraiser-grade Data Lake instead.",
+  },
+  {
+    question: "What makes the Deal Screen's data different?",
+    answer:
+      "It's powered by a growing, appraiser-grade Data Lake — real appraisal workfiles, decades of appraiser trainings, and a community that compounds. Every workfile and member makes the warehouse deeper and the reads sharper, so a Deal Screen taps an ongoing AI powerhouse rather than a one-off answer, the way Grok sits on top of X. That's a compounding edge no general-purpose model can match. It remains decision-support — not an appraisal.",
+  },
 ];
 
 export default function DealScreenPage() {
   return (
     <div>
+      {/* SAL-39 / SAL-48 — fire the funnel page-view event on mount */}
+      <DealScreenPageAnalytics />
+
       {/* HERO */}
       <section className="relative overflow-hidden bg-gradient-to-br from-deep-charcoal to-accent text-white">
         <div className="container mx-auto grid items-center gap-12 px-4 py-16 sm:px-6 md:py-24 lg:grid-cols-2 lg:px-8">
@@ -182,6 +198,9 @@ export default function DealScreenPage() {
         </p>
       </section>
 
+      {/* WHY A REGULAR AI CHATBOT WON'T WORK + DATA-LAKE MOAT (SAL-38 / SAL-55) */}
+      <DealScreenMoatSection />
+
       {/* PRICE FRAMING */}
       <section className="bg-light-gray py-16 md:py-24">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
@@ -231,21 +250,18 @@ export default function DealScreenPage() {
               flags, and pro-forma.
             </p>
           </div>
-          <div className="mx-auto max-w-2xl">
+          <div className="mx-auto max-w-2xl space-y-6">
             <DealScreenOrderForm id="bottom-order-form" />
+            {/* SAL-29 — disclaimer directly under the order form */}
+            <DealScreenDisclaimer />
           </div>
         </div>
       </section>
 
-      {/* Compliance line */}
+      {/* SAL-29 — Compliance disclaimer (footer area) */}
       <section className="bg-background py-8">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8">
-          <p className="mx-auto max-w-3xl text-center text-sm text-muted-foreground">
-            Decision-support only &mdash; not an appraisal, not for lending. The
-            Deal Screen is a professional opinion to support your purchase
-            decision and does not guarantee any value, sale price, or appraised
-            value.
-          </p>
+          <DealScreenDisclaimer />
         </div>
       </section>
     </div>

--- a/src/app/deal-screen/start/page.tsx
+++ b/src/app/deal-screen/start/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 
 import DealScreenCheckout from "@/components/deal-screen/DealScreenCheckout";
+import DealScreenDisclaimer from "@/components/deal-screen/DealScreenDisclaimer";
 
 export const metadata: Metadata = {
   title: "Complete Your Deal Screen — $49",
@@ -57,6 +58,11 @@ export default async function DealScreenStartPage({
           arv: arvDisplay,
         }}
       />
+
+      {/* SAL-29 — compliance disclaimer on the checkout/start page */}
+      <div className="mt-10">
+        <DealScreenDisclaimer />
+      </div>
     </div>
   );
 }

--- a/src/components/deal-screen/DealScreenCheckout.tsx
+++ b/src/components/deal-screen/DealScreenCheckout.tsx
@@ -28,6 +28,15 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  getAttributionData,
+  sendGTMEvent,
+  sendPurchaseEvent,
+} from "@/lib/gtag";
+import { pushEvent } from "@/lib/gtm";
+
+// Fixed Deal Screen price (in dollars) for conversion-event values.
+const DEAL_SCREEN_PRICE = 49;
 
 // Load Stripe once, outside the component, so it isn't recreated on render.
 const stripePromise = loadStripe(
@@ -111,6 +120,46 @@ function CheckoutForm({
           // Swallowed deliberately: payment succeeded; the webhook + Stripe
           // dashboard remain a backstop if this capture call fails in transit.
         }
+
+        // SAL-39 / SAL-48 — "purchase" funnel event on payment success.
+        const attributionData = getAttributionData();
+        sendPurchaseEvent({
+          transactionId: paymentIntent.id,
+          value: DEAL_SCREEN_PRICE,
+          currency: "USD",
+          items: [
+            {
+              item_id: "DEAL_SCREEN",
+              item_name: "Deal Screen",
+              category: "deal_screen",
+              quantity: 1,
+              price: DEAL_SCREEN_PRICE,
+            },
+          ],
+        });
+        sendGTMEvent("deal_screen_purchase", {
+          page_type: "deal_screen",
+          step_name: "payment_completed",
+          transaction_id: paymentIntent.id,
+          conversion_value: DEAL_SCREEN_PRICE,
+          value: DEAL_SCREEN_PRICE,
+          currency: "USD",
+          ...attributionData,
+        });
+        sendGTMEvent("ads_conversion", {
+          conversion_id: "deal_screen_purchase",
+          conversion_value: DEAL_SCREEN_PRICE,
+          currency: "USD",
+          transaction_id: paymentIntent.id,
+          ...attributionData,
+        });
+        // Legacy event for backwards compatibility.
+        pushEvent("deal_screen_purchase", {
+          page: "/deal-screen/start",
+          transaction_id: paymentIntent.id,
+          value: DEAL_SCREEN_PRICE,
+        });
+
         onSucceeded();
         return;
       }
@@ -184,6 +233,24 @@ export default function DealScreenCheckout({
   const [confirmedEmail, setConfirmedEmail] = useState("");
   const [confirmedName, setConfirmedName] = useState("");
 
+  // SAL-39 / SAL-48 — "checkout started" funnel event when checkout mounts.
+  useEffect(() => {
+    const attributionData = getAttributionData();
+    sendGTMEvent("deal_screen_checkout_started", {
+      page_type: "deal_screen",
+      step: 2,
+      step_name: "checkout_started",
+      conversion_value: 20,
+      value: DEAL_SCREEN_PRICE,
+      currency: "USD",
+      ...attributionData,
+    });
+    pushEvent("deal_screen_checkout_started", {
+      page: "/deal-screen/start",
+      step: 2,
+    });
+  }, []);
+
   const startCheckout = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmedEmail = email.trim();
@@ -221,6 +288,22 @@ export default function DealScreenCheckout({
       setConfirmedEmail(trimmedEmail);
       setConfirmedName(name.trim());
       setClientSecret(data.clientSecret);
+
+      // SAL-39 / SAL-48 — payment begins (PaymentElement is about to render).
+      const attributionData = getAttributionData();
+      sendGTMEvent("deal_screen_payment_started", {
+        page_type: "deal_screen",
+        step: 3,
+        step_name: "payment_started",
+        conversion_value: 30,
+        value: DEAL_SCREEN_PRICE,
+        currency: "USD",
+        ...attributionData,
+      });
+      pushEvent("deal_screen_payment_started", {
+        page: "/deal-screen/start",
+        step: 3,
+      });
     } catch {
       setInitError("We couldn't start checkout. Please try again.");
     } finally {

--- a/src/components/deal-screen/DealScreenDisclaimer.tsx
+++ b/src/components/deal-screen/DealScreenDisclaimer.tsx
@@ -1,0 +1,62 @@
+import { Info } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+interface DealScreenDisclaimerProps {
+  /**
+   * `card` (default) renders a bordered, info-toned callout suited to page
+   * sections. `inline` renders compact muted text for tight spots (e.g. under
+   * a form) where a full callout would be visually heavy.
+   */
+  variant?: "card" | "inline";
+  className?: string;
+}
+
+/**
+ * SAL-29 — Compliance disclaimer for the Deal Screen funnel.
+ *
+ * Single source of truth for the decision-support language so the wording
+ * stays identical across the landing page, the order form, and the checkout
+ * start page. Visually clear (info-toned, not destructive) so it reassures
+ * rather than alarms.
+ */
+export default function DealScreenDisclaimer({
+  variant = "card",
+  className,
+}: DealScreenDisclaimerProps) {
+  const body = (
+    <>
+      This is <strong className="font-semibold">decision-support</strong> — not
+      an appraisal, not an appraisal under USPAP, and not for mortgage lending.
+      Values are ranged opinions of most-probable price for the named recipient
+      only.
+    </>
+  );
+
+  if (variant === "inline") {
+    return (
+      <p
+        className={cn(
+          "text-center text-xs leading-relaxed text-muted-foreground",
+          className
+        )}
+        role="note"
+      >
+        {body}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      role="note"
+      className={cn(
+        "mx-auto flex max-w-3xl items-start gap-3 rounded-lg border border-accent/20 bg-accent/5 p-4 text-left text-sm leading-relaxed text-muted-foreground",
+        className
+      )}
+    >
+      <Info className="mt-0.5 h-4 w-4 shrink-0 text-accent" aria-hidden="true" />
+      <p>{body}</p>
+    </div>
+  );
+}

--- a/src/components/deal-screen/DealScreenMoatSection.tsx
+++ b/src/components/deal-screen/DealScreenMoatSection.tsx
@@ -1,0 +1,164 @@
+import {
+  BrainCircuit,
+  Database,
+  GraduationCap,
+  ShieldX,
+  Sparkles,
+  Users,
+} from "lucide-react";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+/**
+ * SAL-38 / SAL-55 — "Why a regular AI chatbot won't work" + the Data-Lake moat.
+ *
+ * Two-column contrast: what generic AI gets wrong on valuation, versus the
+ * appraiser-grade Data Lake (workfiles + trainings + community) that powers the
+ * Deal Screen and compounds over time. Copy is kept compliant — the Deal Screen
+ * is decision-support, not an appraisal.
+ */
+
+const genericAiPitfalls: {
+  icon: typeof ShieldX;
+  title: string;
+  body: string;
+}[] = [
+  {
+    icon: BrainCircuit,
+    title: "It hallucinates valuation theory",
+    body: "Ask a general chatbot what a property is worth and it will confidently invent methodology — paraphrasing things it has read rather than applying how value is actually concluded.",
+  },
+  {
+    icon: ShieldX,
+    title: "It invents adjustments",
+    body: "Generic AI makes up comp adjustments out of thin air — numbers with no paired-sales support, no market evidence, and no way to defend them.",
+  },
+  {
+    icon: Sparkles,
+    title: "It shortcuts the value",
+    body: "It jumps straight to a number to be helpful, skipping the comp selection, condition reads, and risk checks that decide whether the price actually makes sense.",
+  },
+  {
+    icon: GraduationCap,
+    title: "It lacks appraiser domain knowledge",
+    body: "Functional obsolescence, location drags, over-improvement, the quirks of a specific submarket — a general model has never sat across the table from these the way an appraiser has.",
+  },
+  {
+    icon: Database,
+    title: "Public-grade data, public-grade answers",
+    body: "With only public records to draw on — and no proprietary warehouse of real appraisal evidence — the result is a public-grade guess, not an appraiser-grade read.",
+  },
+];
+
+const dataLakeEdges: {
+  icon: typeof Database;
+  title: string;
+  body: string;
+}[] = [
+  {
+    icon: Database,
+    title: "Real appraisal workfiles",
+    body: "Our growing Data Lake is built on real appraisal workfiles — the comps, adjustments, and conclusions behind completed work — so the read is grounded in appraiser-grade evidence, not scraped listings.",
+  },
+  {
+    icon: GraduationCap,
+    title: "Appraiser trainings baked in",
+    body: "Decades of valuation training and review notes shape how the read is framed, so the methodology reflects how a seasoned appraiser actually thinks about a deal.",
+  },
+  {
+    icon: Users,
+    title: "A community that compounds",
+    body: "Every workfile, training, and member that joins makes the warehouse deeper and the reads sharper — a moat that compounds with the community, not one any generic model can copy.",
+  },
+];
+
+export default function DealScreenMoatSection() {
+  return (
+    <section className="bg-deep-charcoal py-16 text-white md:py-24">
+      <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto mb-12 max-w-3xl text-center">
+          <h2 className="text-3xl font-bold md:text-4xl">
+            Why a regular AI chatbot won&rsquo;t screen your deal
+          </h2>
+          <p className="mt-4 text-balance text-lg text-slate-300">
+            Ask a general AI &ldquo;what&rsquo;s it worth?&rdquo; and you get a
+            confident guess built on public data. The Deal Screen is built on an
+            appraiser-grade Data Lake instead &mdash; here&rsquo;s the
+            difference.
+          </p>
+        </div>
+
+        <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-2">
+          {/* Generic AI: what goes wrong */}
+          <div>
+            <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold text-slate-100">
+              <ShieldX className="h-5 w-5 text-red-400" aria-hidden="true" />
+              A generic chatbot
+            </h3>
+            <div className="space-y-4">
+              {genericAiPitfalls.map(({ icon: Icon, title, body }) => (
+                <div
+                  key={title}
+                  className="flex gap-4 rounded-lg border border-white/10 bg-white/5 p-5"
+                >
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-red-500/10 text-red-400">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-slate-100">{title}</h4>
+                    <p className="mt-1 text-sm leading-relaxed text-slate-300">
+                      {body}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* The Data Lake moat */}
+          <div>
+            <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold text-slate-100">
+              <Database className="h-5 w-5 text-highlight" aria-hidden="true" />
+              Our appraiser-grade Data Lake
+            </h3>
+            <div className="space-y-4">
+              {dataLakeEdges.map(({ icon: Icon, title, body }) => (
+                <div
+                  key={title}
+                  className="flex gap-4 rounded-lg border border-highlight/30 bg-highlight/10 p-5"
+                >
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-highlight/20 text-highlight">
+                    <Icon className="h-5 w-5" aria-hidden="true" />
+                  </div>
+                  <div>
+                    <h4 className="font-semibold text-slate-100">{title}</h4>
+                    <p className="mt-1 text-sm leading-relaxed text-slate-300">
+                      {body}
+                    </p>
+                  </div>
+                </div>
+              ))}
+
+              <Card className="border-highlight/30 bg-transparent">
+                <CardContent className="p-5">
+                  <p className="text-sm leading-relaxed text-slate-200">
+                    Order a Deal Screen and you&rsquo;re not buying a one-off
+                    answer &mdash; you&rsquo;re tapping an ongoing AI powerhouse
+                    that gets sharper with every workfile and member, the way
+                    Grok sits on top of X. It&rsquo;s a compounding edge no
+                    general-purpose model can match.
+                  </p>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        </div>
+
+        <p className="mx-auto mt-10 max-w-3xl text-center text-xs leading-relaxed text-slate-400">
+          The Deal Screen is decision-support, not an appraisal. It does not
+          guarantee any value, sale price, or appraised value.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/src/components/deal-screen/DealScreenOrderForm.tsx
+++ b/src/components/deal-screen/DealScreenOrderForm.tsx
@@ -25,6 +25,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { getAttributionData, sendGTMEvent } from "@/lib/gtag";
+import { pushEvent } from "@/lib/gtm";
+import DealScreenDisclaimer from "@/components/deal-screen/DealScreenDisclaimer";
 
 // Contract price / target ARV come in as free-text so users can paste
 // "$450,000" or "450000"; we normalize to digits before validating range.
@@ -92,6 +95,27 @@ export default function DealScreenOrderForm({
 
     const arv = normalizeAmount(values.arv);
     if (arv) params.set("arv", arv);
+
+    // SAL-39 / SAL-48 — "address entered / order started" funnel event.
+    const attributionData = getAttributionData();
+    sendGTMEvent("deal_screen_order_started", {
+      page_type: "deal_screen",
+      step: 1,
+      step_name: "address_entered",
+      form_id: id,
+      has_contract: Boolean(contract),
+      has_arv: Boolean(arv),
+      conversion_value: 10,
+      currency: "USD",
+      ...attributionData,
+    });
+    // Legacy event for backwards compatibility (parallels Start_Booking).
+    pushEvent("deal_screen_order_started", {
+      page: "/deal-screen",
+      step: 1,
+      action: "continue_click",
+      form_id: id,
+    });
 
     router.push(`/deal-screen/start?${params.toString()}`);
   };
@@ -187,9 +211,8 @@ export default function DealScreenOrderForm({
               <ArrowRight className="ml-2 h-5 w-5 transition-transform group-hover:translate-x-1" />
             </Button>
 
-            <p className="text-center text-xs text-muted-foreground">
-              Decision-support only &mdash; not an appraisal, not for lending.
-            </p>
+            {/* SAL-29 — compliance disclaimer inside the order form */}
+            <DealScreenDisclaimer variant="inline" />
           </form>
         </Form>
       </CardContent>

--- a/src/components/deal-screen/DealScreenPageAnalytics.tsx
+++ b/src/components/deal-screen/DealScreenPageAnalytics.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { getAttributionData, sendGTMEvent } from "@/lib/gtag";
+import { pushEvent } from "@/lib/gtm";
+
+/**
+ * SAL-39 / SAL-48 — Deal Screen funnel page-view event.
+ *
+ * The landing page is a server component, so we fire the page-view from this
+ * small client child on mount. Mirrors the `/book` page-view pattern: enhanced
+ * `page_view` with attribution + a legacy `pushEvent` for backwards-compat.
+ */
+export default function DealScreenPageAnalytics() {
+  useEffect(() => {
+    const attributionData = getAttributionData();
+
+    sendGTMEvent("page_view", {
+      page_type: "deal_screen",
+      page_location: window.location.href,
+      page_title: document.title,
+      page_path: "/deal-screen",
+      step_name: "deal_screen_page_view",
+      conversion_value: 5,
+      currency: "USD",
+      ...attributionData,
+    });
+
+    // Funnel-specific view event (parallels `booking_page_view`).
+    sendGTMEvent("deal_screen_page_view", {
+      page_type: "deal_screen",
+      conversion_value: 5,
+      currency: "USD",
+      ...attributionData,
+    });
+
+    // Legacy event for backwards compatibility.
+    pushEvent("page_view", {
+      page: "/deal-screen",
+      page_type: "deal_screen",
+    });
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
Completes the Deal Screen funnel front-end.

Fixes SAL-29
Fixes SAL-38
Fixes SAL-39
Fixes SAL-48
Fixes SAL-55

- `DealScreenDisclaimer` (not-an-appraisal / not-for-lending) on landing, order form, checkout
- `DealScreenMoatSection`: "why a regular AI chatbot won't work" + appraiser-grade Data-Lake moat + 2 FAQ entries
- Funnel analytics via the existing GTM helpers (view → order started → checkout started → purchase)

Build passes; zero new typecheck errors. Recommend an appraisal-expert copy review before full go-live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)