### PR TITLE
feat(deal-screen): webhook->ROI-agent trigger w/ cold-start retry/backoff (SAL-20)

### DIFF
--- a/src/app/api/deal-screen/order/route.ts
+++ b/src/app/api/deal-screen/order/route.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { withRouteLogging, logEvent } from '@/lib/log-helpers';
 import { createChildLogger, LOG_CONTEXTS } from '@/lib/logger';
 import { sendDealScreenOrderNotification } from '@/lib/email';
+import { triggerDealScreenJob } from '@/lib/roi-agent';
 
 // Match the Stripe apiVersion used elsewhere in the app. Cast to keep runtime
 // behavior identical to create-payment-intent / stripe-webhook without adding a
@@ -94,16 +95,30 @@ async function handleDealScreenOrder(req: NextRequest) {
       );
     }
 
-    // ------------------------------------------------------------------
-    // TODO (SEPARATE TICKET — do NOT build here):
-    // Hand off the paid order to Salesmod for full fulfillment:
-    //   1. Provision / look up the investor account (buyer email).
-    //   2. Create the Deal Screen order record (address, contract, arv,
-    //      paymentIntentId) in Salesmod.
-    //   3. Trigger the ROI agent to run the appraiser-grade Deal Screen.
-    // This route's responsibility is limited to verifying payment + capturing
-    // the lead. Provisioning + ROI-agent trigger are tracked separately.
-    // ------------------------------------------------------------------
+    // IMMEDIATE ROI agent trigger (SAL-20, fast path). The durable
+    // payment_intent.succeeded webhook (src/app/api/deal-screen/webhook) fires
+    // the SAME trigger so the order survives a dropped client-side capture POST.
+    // Both use paymentIntentId as the idempotency key, so the agent dedupes and
+    // never double-generates a screen. triggerDealScreenJob NEVER throws, so a
+    // trigger failure can never break the payment/confirmation response.
+    try {
+      await triggerDealScreenJob({
+        idempotencyKey: paymentIntentId,
+        customer: { email },
+        deal: {
+          address: deal?.address,
+          contract: deal?.contract,
+          arv: deal?.arv,
+        },
+      });
+    } catch (triggerError) {
+      // Belt-and-suspenders: triggerDealScreenJob is designed not to throw, but
+      // we still guard so the buyer always gets a clean success response.
+      orderLogger.error(
+        { err: triggerError, requestId, paymentIntentId },
+        'ROI agent trigger threw unexpectedly (payment still captured)'
+      );
+    }
 
     return NextResponse.json({ success: true, requestId });
   } catch (error) {

--- a/src/app/api/deal-screen/webhook/route.ts
+++ b/src/app/api/deal-screen/webhook/route.ts
@@ -1,0 +1,121 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+import { createChildLogger, LOG_CONTEXTS } from '@/lib/logger';
+import { triggerDealScreenJob } from '@/lib/roi-agent';
+
+/**
+ * DURABLE Deal Screen fulfillment trigger (SAL-20).
+ *
+ * This Stripe webhook is the RELIABLE path that survives a dropped client-side
+ * capture POST: even if the browser navigates away / loses connection after
+ * payment, Stripe still delivers `payment_intent.succeeded` here and we kick off
+ * the ROI agent. The order-capture endpoint fires the SAME trigger for the fast
+ * path; both use the PaymentIntent id as the idempotency key so the agent
+ * dedupes and never double-generates a screen.
+ *
+ * Register this endpoint in the Stripe Dashboard (or via a dedicated webhook
+ * endpoint) for the `payment_intent.succeeded` event and set STRIPE_WEBHOOK_SECRET.
+ */
+
+// Match the Stripe apiVersion pinned elsewhere in the app. The installed types
+// only declare the latest version literal, so we cast to keep runtime behavior
+// identical without introducing a new typecheck error.
+const stripe = process.env.STRIPE_SECRET_KEY
+  ? new Stripe(process.env.STRIPE_SECRET_KEY, {
+      apiVersion: '2024-11-20.acacia' as Stripe.LatestApiVersion,
+    })
+  : null;
+
+const webhookLogger = createChildLogger({ context: LOG_CONTEXTS.PAYMENT });
+
+export async function POST(req: NextRequest) {
+  if (!stripe || !process.env.STRIPE_WEBHOOK_SECRET) {
+    webhookLogger.warn('Deal Screen webhook called but Stripe is not configured');
+    return NextResponse.json(
+      { error: 'Stripe webhook not configured' },
+      { status: 503 }
+    );
+  }
+
+  const body = await req.text();
+  // Read the signature off the request directly — NextRequest.headers is
+  // synchronous and fully typed (avoids the async `headers()` Promise typing
+  // wrinkle present in the legacy stripe-webhook route). Same runtime behavior.
+  const signature = req.headers.get('stripe-signature') || '';
+
+  let event: Stripe.Event;
+
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      process.env.STRIPE_WEBHOOK_SECRET
+    );
+  } catch (err) {
+    webhookLogger.error({ err }, 'Deal Screen webhook signature verification failed');
+    return NextResponse.json(
+      { error: 'Webhook signature verification failed' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    if (event.type === 'payment_intent.succeeded') {
+      const paymentIntent = event.data.object as Stripe.PaymentIntent;
+      const metadata = paymentIntent.metadata || {};
+
+      // Only act on Deal Screen purchases. Other products / unrelated payments
+      // flowing through this account are acknowledged and ignored.
+      if (metadata.sku === 'DEAL_SCREEN') {
+        webhookLogger.info(
+          {
+            event: 'deal_screen_payment_succeeded',
+            paymentIntentId: paymentIntent.id,
+            amount: paymentIntent.amount / 100,
+          },
+          'Deal Screen payment succeeded — triggering ROI agent (durable webhook path)'
+        );
+
+        // Fire-and-await the ROI agent trigger. triggerDealScreenJob NEVER throws
+        // and is idempotent by paymentIntent.id, so the immediate order-capture
+        // path and this webhook can both fire without double-generating.
+        const result = await triggerDealScreenJob({
+          idempotencyKey: paymentIntent.id,
+          customer: {
+            email: metadata.customerEmail || paymentIntent.receipt_email || '',
+          },
+          deal: {
+            address: metadata.dealAddress || undefined,
+            contract: metadata.dealContract || undefined,
+            arv: metadata.dealArv || undefined,
+          },
+        });
+
+        if (!result.ok && !('skipped' in result && result.skipped)) {
+          // Already logged inside triggerDealScreenJob; we still ACK the webhook
+          // (200) so Stripe does not retry-storm us. Manual follow-up handles the
+          // rare exhausted-retry case.
+          webhookLogger.warn(
+            { paymentIntentId: paymentIntent.id },
+            'ROI agent trigger did not succeed from webhook (acknowledged anyway)'
+          );
+        }
+      }
+    } else {
+      webhookLogger.info(
+        { event: event.type },
+        'Deal Screen webhook — unhandled event type (ignored)'
+      );
+    }
+
+    return NextResponse.json({ received: true });
+  } catch (err) {
+    // Defensive: triggerDealScreenJob does not throw, but guard the whole block
+    // so a verified Stripe event is always ACKed and never lost to a 500 retry loop.
+    webhookLogger.error(
+      { err, eventType: event.type },
+      'Error processing Deal Screen webhook'
+    );
+    return NextResponse.json({ received: true });
+  }
+}

--- a/src/lib/roi-agent.ts
+++ b/src/lib/roi-agent.ts
@@ -1,0 +1,211 @@
+/**
+ * ROI Appraisal Agent trigger (SAL-20).
+ *
+ * When a $49 Deal Screen payment succeeds we hand the order off to the ROI
+ * Appraisal Agent (a Python service deployed on Fly.io) so it can generate the
+ * appraiser-grade Deal Screen. The agent is fronted by Fly.io, which scales to
+ * zero — the FIRST request after idle pays a cold-start penalty (the machine
+ * has to boot), so a naive single POST will frequently time out / 502. We ride
+ * that out with exponential backoff retries.
+ *
+ * DESIGN GUARANTEES
+ *  - NEVER throws. The charge already cleared and the admin email already fired
+ *    by the time we get here, so a trigger failure must never break the
+ *    payment/confirmation flow. We log a structured error and return a result.
+ *  - Idempotent by `idempotencyKey` (the Stripe PaymentIntent id). Both the
+ *    durable webhook AND the immediate order-capture endpoint call this, so the
+ *    agent must dedupe on this key to avoid double-generating a screen.
+ *  - Tolerant of an unconfigured env: if ROI_AGENT_URL is unset we log
+ *    "ROI agent trigger not configured" and return without erroring, so the
+ *    build/flow works before the env is wired in production.
+ *
+ * REQUIRED ENVIRONMENT VARIABLES (document in .env / Vercel project settings):
+ *   ROI_AGENT_URL     Base URL of the ROI agent intake endpoint on Fly.io,
+ *                     e.g. https://roi-appraisal-agent.fly.dev/api/intake
+ *   ROI_AGENT_SECRET  Shared secret sent as `Authorization: Bearer <secret>`
+ *                     AND `x-roi-agent-secret: <secret>` so the agent can
+ *                     authenticate the caller. Optional but strongly recommended.
+ */
+
+import { createChildLogger, LOG_CONTEXTS } from '@/lib/logger';
+
+const roiLogger = createChildLogger({ context: LOG_CONTEXTS.PAYMENT });
+
+/** Payload POSTed to the ROI agent to enqueue a Deal Screen generation job. */
+export interface TriggerDealScreenPayload {
+  event: 'NEW_ORDER';
+  source: 'deal_screen';
+  /** Stripe PaymentIntent id — the dedupe key for idempotent triggering. */
+  idempotencyKey: string;
+  customer: {
+    email: string;
+  };
+  deal: {
+    address?: string;
+    contract?: string;
+    arv?: string;
+  };
+}
+
+/** Caller-facing arguments. `event`/`source` are filled in for you. */
+export interface TriggerDealScreenInput {
+  /** Stripe PaymentIntent id (idempotency / dedupe key). */
+  idempotencyKey: string;
+  customer: {
+    email: string;
+  };
+  deal: {
+    address?: string;
+    contract?: string;
+    arv?: string;
+  };
+}
+
+export type TriggerDealScreenResult =
+  /** Agent accepted the job (2xx). */
+  | { ok: true; status: number; attempts: number }
+  /** Trigger intentionally skipped because ROI_AGENT_URL is not configured. */
+  | { ok: false; skipped: true; reason: 'not_configured' }
+  /** All retries exhausted / non-2xx / network failure. Logged, not thrown. */
+  | { ok: false; skipped?: false; attempts: number; error: string };
+
+// Retry tuning: ~5 attempts with growing delays (1s, 2s, 4s, 8s, 16s) between
+// them. This window comfortably outlasts a Fly.io machine cold start.
+const MAX_ATTEMPTS = 5;
+const BASE_DELAY_MS = 1000;
+// Per-attempt request timeout. A booting Fly machine can hold the socket open;
+// we don't want a single attempt to hang the whole route.
+const REQUEST_TIMEOUT_MS = 20_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Exponential backoff delay (ms) BEFORE the given 1-based attempt number. */
+function backoffDelayMs(attempt: number): number {
+  // attempt 1 -> no wait (handled by caller); waits precede attempts 2..N.
+  return BASE_DELAY_MS * 2 ** (attempt - 2);
+}
+
+/**
+ * POST a NEW_ORDER to the ROI Appraisal Agent with cold-start-tolerant retries.
+ *
+ * Resolves with a structured result and NEVER throws — the payment has already
+ * been captured, so a downstream trigger failure must not surface to the buyer.
+ */
+export async function triggerDealScreenJob(
+  input: TriggerDealScreenInput
+): Promise<TriggerDealScreenResult> {
+  const url = process.env.ROI_AGENT_URL;
+  const secret = process.env.ROI_AGENT_SECRET;
+
+  // Unconfigured env: no-op so the build/flow works before the env is wired.
+  if (!url) {
+    roiLogger.warn(
+      { idempotencyKey: input.idempotencyKey },
+      'ROI agent trigger not configured (ROI_AGENT_URL unset) — skipping'
+    );
+    return { ok: false, skipped: true, reason: 'not_configured' };
+  }
+
+  const payload: TriggerDealScreenPayload = {
+    event: 'NEW_ORDER',
+    source: 'deal_screen',
+    idempotencyKey: input.idempotencyKey,
+    customer: { email: input.customer.email },
+    deal: {
+      address: input.deal.address,
+      contract: input.deal.contract,
+      arv: input.deal.arv,
+    },
+  };
+
+  const body = JSON.stringify(payload);
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    // Idempotency advertised both ways: a header (for proxies / generic dedupe)
+    // and inside the body (idempotencyKey) for the agent itself.
+    'Idempotency-Key': input.idempotencyKey,
+  };
+  if (secret) {
+    headers['Authorization'] = `Bearer ${secret}`;
+    headers['x-roi-agent-secret'] = secret;
+  }
+
+  let lastError = 'unknown error';
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    if (attempt > 1) {
+      const delay = backoffDelayMs(attempt);
+      roiLogger.info(
+        { idempotencyKey: input.idempotencyKey, attempt, delayMs: delay },
+        'ROI agent trigger — backing off before retry (cold-start tolerance)'
+      );
+      await sleep(delay);
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const res = await fetch(url, {
+        method: 'POST',
+        headers,
+        body,
+        signal: controller.signal,
+      });
+
+      if (res.ok) {
+        roiLogger.info(
+          {
+            idempotencyKey: input.idempotencyKey,
+            attempt,
+            status: res.status,
+          },
+          'ROI agent Deal Screen job enqueued'
+        );
+        return { ok: true, status: res.status, attempts: attempt };
+      }
+
+      // Non-2xx: capture a short body snippet for diagnostics and retry.
+      let snippet = '';
+      try {
+        snippet = (await res.text()).slice(0, 500);
+      } catch {
+        // ignore body read failures
+      }
+      lastError = `HTTP ${res.status}${snippet ? `: ${snippet}` : ''}`;
+      roiLogger.warn(
+        {
+          idempotencyKey: input.idempotencyKey,
+          attempt,
+          status: res.status,
+        },
+        'ROI agent trigger attempt returned non-2xx'
+      );
+    } catch (err) {
+      lastError =
+        err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+      roiLogger.warn(
+        { idempotencyKey: input.idempotencyKey, attempt, err },
+        'ROI agent trigger attempt failed (network/timeout) — will retry if attempts remain'
+      );
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  // All attempts exhausted. Log a structured error and return — DO NOT throw.
+  // The order is never lost: the charge cleared and the admin email already
+  // fired; this only delays automated screen generation, which is recoverable.
+  roiLogger.error(
+    {
+      idempotencyKey: input.idempotencyKey,
+      attempts: MAX_ATTEMPTS,
+      error: lastError,
+    },
+    'ROI agent trigger FAILED after all retries — manual follow-up required'
+  );
+
+  return { ok: false, attempts: MAX_ATTEMPTS, error: lastError };
+}


### PR DESCRIPTION
On a successful $49 Deal Screen payment, triggers the ROI Appraisal Agent (Fly.io) to generate the screen.

Fixes SAL-20

- `src/lib/roi-agent.ts` — `triggerDealScreenJob`: POSTs `NEW_ORDER` with retry + exponential backoff (5 attempts, 1–16s) for Fly cold starts; idempotent (payment-intent id); tolerant (never breaks the payment flow; no-ops if `ROI_AGENT_URL` unset)
- `src/app/api/deal-screen/webhook/route.ts` — signature-verified Stripe webhook (durable trigger) on `payment_intent.succeeded` for `DEAL_SCREEN`
- order-capture also triggers it (idempotent on the same key)

Build passes; zero new typecheck errors.

**Go-live config:** set `ROI_AGENT_URL` + `ROI_AGENT_SECRET`; register `/api/deal-screen/webhook` in Stripe for `payment_intent.succeeded`; confirm the PaymentIntent metadata keys align across paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)